### PR TITLE
Fix build error where Retyped depended on itself

### DIFF
--- a/src/retyped/optimizer.re
+++ b/src/retyped/optimizer.re
@@ -40,7 +40,6 @@ let optimize_statements types statements =>
 
 let optimize types::(types: list (string, Typetable.t)) program =>
   switch program {
-  | ModuleDecl id statements =>
-    ModuleDecl id (optimize_statements types statements)
+  | ModuleDecl id statements => ModuleDecl id (optimize_statements types statements)
   | s => s
   };

--- a/src/retyped/optimizer.re
+++ b/src/retyped/optimizer.re
@@ -38,7 +38,7 @@ let optimize_statements types statements =>
     )
     statements;
 
-let optimize types::(types: list (string, Retyped.Typetable.t)) program =>
+let optimize types::(types: list (string, Typetable.t)) program =>
   switch program {
   | ModuleDecl id statements =>
     ModuleDecl id (optimize_statements types statements)


### PR DESCRIPTION
<!-- Please provide a brief description of the changes -->
As we discussed on Discord, the build was failing with this error:
```
Module Optimizer in directory _build/default/src/retyped depends on Retyped.
This doesn't make sense to me.

Retyped is the main module of the library and is the only module exposed 
outside of the library. Consequently it should be the one dependending 
on all the other modules in the library.
```
Removing the Retyped. prefixing from the function call fixed the build.

There were no changes to the snapshots.
<!-- If possible, provide sample input and output -->

### PR Checklist
- [ ] Corresponding issue:
- [x] Formatted code with `refmt`
- [x] Ran tests `npm test` and updated snapshots
