### PR TITLE
Output Reason 3 syntax. Support optional object properites. Test with…

### DIFF
--- a/lib/__tests__/__snapshots__/compile.js.snap
+++ b/lib/__tests__/__snapshots__/compile.js.snap
@@ -1,162 +1,191 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Compile duplicate-type.re 1`] = `
-"external add : x::[ | \`Number float | \`String string] [@bs.unwrap] => float =
-  \\"\\" [@@bs.module \\"duplicate-type\\"];
+exports[`Compile component.re 1`] = `
+"type props = {. \\"input\\": Js.Nullable.t(string), \\"b\\": Js.Nullable.t(Js.boolean)};
 
-external sub : x::[ | \`Number float | \`String string] [@bs.unwrap] => float =
-  \\"\\" [@@bs.module \\"duplicate-type\\"];
+module ReactComponent = {
+  [@bs.module \\"react-component\\"] external reactcomponent_reactComponent : ReasonReact.reactClass =
+    \\"ReactComponent\\";
+  let make = (~input=?, ~b=?, children) => {
+    let props: props = {
+      \\"input\\": Js.Nullable.from_opt(input),
+      \\"b\\": Js.Nullable.bind(Js.Nullable.from_opt(b), [@bs] ((x) => Js.Boolean.to_js_boolean(x)))
+    };
+    ReasonReact.wrapJsForReason(~reactClass=reactcomponent_reactComponent, ~props, children)
+  };
+};
+"
+`;
+
+exports[`Compile duplicate-type.re 1`] = `
+"[@bs.module \\"duplicate-type\\"]
+external add : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float =
+  \\"\\";
+
+[@bs.module \\"duplicate-type\\"]
+external sub : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float =
+  \\"\\";
 "
 `;
 
 exports[`Compile duplicate-type-param.re 1`] = `
-"external add :
-  x::[ | \`Number float | \`String string] [@bs.unwrap] =>
-  y::[ | \`Number float | \`String string] [@bs.unwrap] =>
+"[@bs.module \\"duplicate-type-param\\"]
+external add :
+  (
+    ~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)],
+    ~y: [@bs.unwrap] [ | \`Number(float) | \`String(string)]
+  ) =>
   float =
-  \\"\\" [@@bs.module \\"duplicate-type-param\\"];
+  \\"\\";
 "
 `;
 
 exports[`Compile generics.re 1`] = `
-"type thing 'x = Js.t {. lst : array 'x};
+"type thing('x) = {. \\"lst\\": array('x)};
 
 module Adder = {
-  type t 'x = Js.t {. add : ('x => 'x) [@bs.meth]};
-  external make : 'x => t 'x = \\"Adder\\" [@@bs.new] [@@bs.module \\"generics\\"];
+  type t('x) = {. \\"add\\": [@bs.meth] ('x => 'x)};
+  [@bs.new] [@bs.module \\"generics\\"] external make : 'x => t('x) = \\"Adder\\";
 };
 
-type subOpts 'm 'n = Js.t {. m : 'm, n : Adder.t 'n};
+type subOpts('m, 'n) = {. \\"m\\": 'm, \\"n\\": Adder.t('n)};
 "
 `;
 
 exports[`Compile interface.re 1`] = `
-"type options = Js.t {. op : string};
+"type options = {. \\"op\\": string};
 
-external apply : x::float => y::float => options::options? => unit => float =
-  \\"\\" [@@bs.module \\"interface\\"];
+[@bs.module \\"interface\\"]
+external apply : (~x: float, ~y: float, ~options: options=?, unit) => float =
+  \\"\\";
 "
 `;
 
 exports[`Compile multiple-modules.re 1`] = `
-"external someTopLevel : unit => unit = \\"\\" [@@bs.module \\"multiple-modules\\"];
+"[@bs.module \\"multiple-modules\\"] external someTopLevel : unit => unit = \\"\\";
 
 module First = {
-  external first : unit => float = \\"\\" [@@bs.module \\"multiple-modules/first\\"];
-  external second : unit => unit = \\"\\" [@@bs.module \\"multiple-modules/first\\"];
+  [@bs.module \\"multiple-modules/first\\"] external first : unit => float = \\"\\";
+  [@bs.module \\"multiple-modules/first\\"] external second : unit => unit = \\"\\";
 };
 
 module Second = {
-  external second : unit => string = \\"\\" [@@bs.module \\"multiple-modules/second\\"];
-  external third : unit => unit = \\"\\" [@@bs.module \\"multiple-modules/second\\"];
+  [@bs.module \\"multiple-modules/second\\"] external second : unit => string = \\"\\";
+  [@bs.module \\"multiple-modules/second\\"] external third : unit => unit = \\"\\";
 };
 
 module Third = {
-  external third : unit => string = \\"\\" [@@bs.module \\"multiple-modules/third\\"];
-  external fourth : unit => unit = \\"\\" [@@bs.module \\"multiple-modules/third\\"];
+  [@bs.module \\"multiple-modules/third\\"] external third : unit => string = \\"\\";
+  [@bs.module \\"multiple-modules/third\\"] external fourth : unit => unit = \\"\\";
 };
 
 module ThirdInner = {
-  external third : unit => string = \\"\\" [@@bs.module \\"multiple-modules/third/inner\\"];
-  external fourth : unit => unit = \\"\\" [@@bs.module \\"multiple-modules/third/inner\\"];
+  [@bs.module \\"multiple-modules/third/inner\\"] external third : unit => string = \\"\\";
+  [@bs.module \\"multiple-modules/third/inner\\"] external fourth : unit => unit = \\"\\";
 };
 "
 `;
 
 exports[`Compile numbers.re 1`] = `
-"external xfg : float = \\"\\" [@@bs.module \\"numbers\\"];
+"[@bs.module \\"numbers\\"] external xfg : float = \\"\\";
 
-external add : a::float => b::float => float = \\"\\" [@@bs.module \\"numbers\\"];
+[@bs.module \\"numbers\\"] external add : (~a: float, ~b: float) => float = \\"\\";
 "
 `;
 
 exports[`Compile numbers.re 2`] = `
-"external xfg : float = \\"\\" [@@bs.module \\"numbers\\"];
+"[@bs.module \\"numbers\\"] external xfg : float = \\"\\";
 
-external add : a::float => b::float => float = \\"\\" [@@bs.module \\"numbers\\"];
+[@bs.module \\"numbers\\"] external add : (~a: float, ~b: float) => float = \\"\\";
 "
 `;
 
 exports[`Compile object-type.re 1`] = `
-"type subscribeOptions = Js.t {. start : float, stop : float};
+"type subscribeOptions = {. \\"start\\": float, \\"stop\\": float};
 
-type testOptions = Js.t {. method : string, subscribe : subscribeOptions};
+type testOptions = {. \\"method\\": string, \\"subscribe\\": subscribeOptions};
 
-external test : options::testOptions => string = \\"\\" [@@bs.module \\"object-type\\"];
+[@bs.module \\"object-type\\"] external test : (~options: testOptions) => string = \\"\\";
 "
 `;
 
 exports[`Compile optional-param.re 1`] = `
-"external add : x::float => y::float? => unit => float = \\"\\" [@@bs.module \\"optional\\"];
+"[@bs.module \\"optional\\"] external add : (~x: float, ~y: float=?, unit) => float = \\"\\";
 "
 `;
 
 exports[`Compile promise.re 1`] = `
-"external pOfString : unit => Js_promise.t string = \\"\\" [@@bs.module \\"promise\\"];
+"[@bs.module \\"promise\\"] external pOfString : unit => Js_promise.t(string) = \\"\\";
 
-external pOfNumber : unit => Js_promise.t float = \\"\\" [@@bs.module \\"promise\\"];
+[@bs.module \\"promise\\"] external pOfNumber : unit => Js_promise.t(float) = \\"\\";
 
-external pOfArray : unit => Js_promise.t (array string) = \\"\\" [@@bs.module \\"promise\\"];
+[@bs.module \\"promise\\"] external pOfArray : unit => Js_promise.t(array(string)) = \\"\\";
 
-external pOfVoid : unit => Js_promise.t unit = \\"\\" [@@bs.module \\"promise\\"];
+[@bs.module \\"promise\\"] external pOfVoid : unit => Js_promise.t(unit) = \\"\\";
 
-external argPromise : p::Js_promise.t string => unit = \\"\\" [@@bs.module \\"promise\\"];
+[@bs.module \\"promise\\"] external argPromise : (~p: Js_promise.t(string)) => unit = \\"\\";
 
-external listOfPromises : unit => array (Js_promise.t string) = \\"\\" [@@bs.module \\"promise\\"];
+[@bs.module \\"promise\\"] external listOfPromises : unit => array(Js_promise.t(string)) = \\"\\";
 
-external somePromise : Js_promise.t (array float) = \\"\\" [@@bs.module \\"promise\\"];
+[@bs.module \\"promise\\"] external somePromise : Js_promise.t(array(float)) = \\"\\";
 "
 `;
 
 exports[`Compile simple.re 1`] = `
-"external add : x::float => y::float => float = \\"\\" [@@bs.module \\"simple\\"];
+"[@bs.module \\"simple\\"] external add : (~x: float, ~y: float) => float = \\"\\";
 "
 `;
 
 exports[`Compile simple-class.re 1`] = `
 "module Test = {
-  type t = Js.t {. action : (float => string) [@bs.meth]};
-  external make : string => t = \\"Test\\" [@@bs.new] [@@bs.module \\"simple-class\\"];
+  type t = {. \\"action\\": 't 's .[@bs.meth] (float => string)};
+  [@bs.new] [@bs.module \\"simple-class\\"] external make : string => t = \\"Test\\";
 };
 "
 `;
 
 exports[`Compile spread-args.re 1`] = `
-"external foo : bars::array float => unit = \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+"[@bs.module \\"spread-args\\"] [@bs.splice] external foo : (~bars: array(float)) => unit = \\"\\";
 
-external optFoo : bars::array float => unit = \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+[@bs.module \\"spread-args\\"] [@bs.splice] external optFoo : (~bars: array(float)) => unit = \\"\\";
 
-external bothFoo : anArg::string => bars::array float => unit =
-  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+[@bs.module \\"spread-args\\"] [@bs.splice]
+external bothFoo : (~anArg: string, ~bars: array(float)) => unit =
+  \\"\\";
 
-external bothOptFoo : anArg::string => bars::array float => unit =
-  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+[@bs.module \\"spread-args\\"] [@bs.splice]
+external bothOptFoo : (~anArg: string, ~bars: array(float)) => unit =
+  \\"\\";
 
-external soManyOpts : anArg::string? => unit => bars::array float => unit =
-  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+[@bs.module \\"spread-args\\"] [@bs.splice]
+external soManyOpts : (~anArg: string=?, unit, ~bars: array(float)) => unit =
+  \\"\\";
 
-external returns : anArg::string => bars::array float => float =
-  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+[@bs.module \\"spread-args\\"] [@bs.splice]
+external returns : (~anArg: string, ~bars: array(float)) => float =
+  \\"\\";
 
-external multipleLists : foos::array float => bars::array float => unit =
-  \\"\\" [@@bs.module \\"spread-args\\"] [@@bs.splice];
+[@bs.module \\"spread-args\\"] [@bs.splice]
+external multipleLists : (~foos: array(float), ~bars: array(float)) => unit =
+  \\"\\";
 "
 `;
 
 exports[`Compile type-decl.re 1`] = `
-"type stringOptions = Js.t {. value : string};
+"type stringOptions = {. \\"value\\": string};
 
-external test : s::string => options::stringOptions => string = \\"\\" [@@bs.module \\"type-decl\\"];
+[@bs.module \\"type-decl\\"] external test : (~s: string, ~options: stringOptions) => string = \\"\\";
 "
 `;
 
 exports[`Compile union-type.re 1`] = `
-"external double : x::[ | \`Number float | \`String string] [@bs.unwrap] => float =
-  \\"\\" [@@bs.module \\"union-type\\"];
+"[@bs.module \\"union-type\\"]
+external double : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float =
+  \\"\\";
 "
 `;
 
 exports[`Compile void-func.re 1`] = `
-"external voidFunc : unit => unit = \\"\\" [@@bs.module \\"void-func\\"];
+"[@bs.module \\"void-func\\"] external voidFunc : unit => unit = \\"\\";
 "
 `;

--- a/lib/__tests__/fixtures/component.js
+++ b/lib/__tests__/fixtures/component.js
@@ -1,0 +1,6 @@
+import type { Component } from 'react'
+
+declare module 'react-component' {
+  declare type props = { input?: string, b?: boolean }
+  declare export class ReactComponent extends Component<props> {}
+}

--- a/lib/__tests__/fixtures/component.re
+++ b/lib/__tests__/fixtures/component.re
@@ -1,0 +1,13 @@
+type props = {. "input": Js.Nullable.t(string), "b": Js.Nullable.t(Js.boolean)};
+
+module ReactComponent = {
+  [@bs.module "react-component"] external reactcomponent_reactComponent : ReasonReact.reactClass =
+    "ReactComponent";
+  let make = (~input=?, ~b=?, children) => {
+    let props: props = {
+      "input": Js.Nullable.from_opt(input),
+      "b": Js.Nullable.bind(Js.Nullable.from_opt(b), [@bs] ((x) => Js.Boolean.to_js_boolean(x)))
+    };
+    ReasonReact.wrapJsForReason(~reactClass=reactcomponent_reactComponent, ~props, children)
+  };
+};

--- a/lib/__tests__/fixtures/duplicate-type-param.re
+++ b/lib/__tests__/fixtures/duplicate-type-param.re
@@ -1,5 +1,8 @@
+[@bs.module "duplicate-type-param"]
 external add :
-  x::[ | `Number float | `String string] [@bs.unwrap] =>
-  y::[ | `Number float | `String string] [@bs.unwrap] =>
+  (
+    ~x: [@bs.unwrap] [ | `Number(float) | `String(string)],
+    ~y: [@bs.unwrap] [ | `Number(float) | `String(string)]
+  ) =>
   float =
-  "" [@@bs.module "duplicate-type-param"];
+  "";

--- a/lib/__tests__/fixtures/duplicate-type.re
+++ b/lib/__tests__/fixtures/duplicate-type.re
@@ -1,5 +1,7 @@
-external add : x::[ | `Number float | `String string] [@bs.unwrap] => float =
-  "" [@@bs.module "duplicate-type"];
+[@bs.module "duplicate-type"]
+external add : (~x: [@bs.unwrap] [ | `Number(float) | `String(string)]) => float =
+  "";
 
-external sub : x::[ | `Number float | `String string] [@bs.unwrap] => float =
-  "" [@@bs.module "duplicate-type"];
+[@bs.module "duplicate-type"]
+external sub : (~x: [@bs.unwrap] [ | `Number(float) | `String(string)]) => float =
+  "";

--- a/lib/__tests__/fixtures/generics.re
+++ b/lib/__tests__/fixtures/generics.re
@@ -1,8 +1,8 @@
-type thing 'x = Js.t {. lst : array 'x};
+type thing('x) = {. "lst": array('x)};
 
 module Adder = {
-  type t 'x = Js.t {. add : ('x => 'x) [@bs.meth]};
-  external make : 'x => t 'x = "Adder" [@@bs.new] [@@bs.module "generics"];
+  type t('x) = {. "add": [@bs.meth] ('x => 'x)};
+  [@bs.new] [@bs.module "generics"] external make : 'x => t('x) = "Adder";
 };
 
-type subOpts 'm 'n = Js.t {. m : 'm, n : Adder.t 'n};
+type subOpts('m, 'n) = {. "m": 'm, "n": Adder.t('n)};

--- a/lib/__tests__/fixtures/interface.re
+++ b/lib/__tests__/fixtures/interface.re
@@ -1,4 +1,5 @@
-type options = Js.t {. op : string};
+type options = {. "op": string};
 
-external apply : x::float => y::float => options::options? => unit => float =
-  "" [@@bs.module "interface"];
+[@bs.module "interface"]
+external apply : (~x: float, ~y: float, ~options: options=?, unit) => float =
+  "";

--- a/lib/__tests__/fixtures/multiple-modules.re
+++ b/lib/__tests__/fixtures/multiple-modules.re
@@ -1,21 +1,21 @@
-external someTopLevel : unit => unit = "" [@@bs.module "multiple-modules"];
+[@bs.module "multiple-modules"] external someTopLevel : unit => unit = "";
 
 module First = {
-  external first : unit => float = "" [@@bs.module "multiple-modules/first"];
-  external second : unit => unit = "" [@@bs.module "multiple-modules/first"];
+  [@bs.module "multiple-modules/first"] external first : unit => float = "";
+  [@bs.module "multiple-modules/first"] external second : unit => unit = "";
 };
 
 module Second = {
-  external second : unit => string = "" [@@bs.module "multiple-modules/second"];
-  external third : unit => unit = "" [@@bs.module "multiple-modules/second"];
+  [@bs.module "multiple-modules/second"] external second : unit => string = "";
+  [@bs.module "multiple-modules/second"] external third : unit => unit = "";
 };
 
 module Third = {
-  external third : unit => string = "" [@@bs.module "multiple-modules/third"];
-  external fourth : unit => unit = "" [@@bs.module "multiple-modules/third"];
+  [@bs.module "multiple-modules/third"] external third : unit => string = "";
+  [@bs.module "multiple-modules/third"] external fourth : unit => unit = "";
 };
 
 module ThirdInner = {
-  external third : unit => string = "" [@@bs.module "multiple-modules/third/inner"];
-  external fourth : unit => unit = "" [@@bs.module "multiple-modules/third/inner"];
+  [@bs.module "multiple-modules/third/inner"] external third : unit => string = "";
+  [@bs.module "multiple-modules/third/inner"] external fourth : unit => unit = "";
 };

--- a/lib/__tests__/fixtures/numbers.re
+++ b/lib/__tests__/fixtures/numbers.re
@@ -1,3 +1,3 @@
-external xfg : float = "" [@@bs.module "numbers"];
+[@bs.module "numbers"] external xfg : float = "";
 
-external add : a::float => b::float => float = "" [@@bs.module "numbers"];
+[@bs.module "numbers"] external add : (~a: float, ~b: float) => float = "";

--- a/lib/__tests__/fixtures/object-type.re
+++ b/lib/__tests__/fixtures/object-type.re
@@ -1,5 +1,5 @@
-type subscribeOptions = Js.t {. start : float, stop : float};
+type subscribeOptions = {. "start": float, "stop": float};
 
-type testOptions = Js.t {. method : string, subscribe : subscribeOptions};
+type testOptions = {. "method": string, "subscribe": subscribeOptions};
 
-external test : options::testOptions => string = "" [@@bs.module "object-type"];
+[@bs.module "object-type"] external test : (~options: testOptions) => string = "";

--- a/lib/__tests__/fixtures/optional-param.re
+++ b/lib/__tests__/fixtures/optional-param.re
@@ -1,1 +1,1 @@
-external add : x::float => y::float? => unit => float = "" [@@bs.module "optional"];
+[@bs.module "optional"] external add : (~x: float, ~y: float=?, unit) => float = "";

--- a/lib/__tests__/fixtures/promise.re
+++ b/lib/__tests__/fixtures/promise.re
@@ -1,7 +1,13 @@
-external pOfString : unit => Js_promise.t string = "" [@@bs.module "promise"];
-external pOfNumber : unit => Js_promise.t float = "" [@@bs.module "promise"];
-external pOfArray : unit => Js_promise.t (array string) = "" [@@bs.module "promise"];
-external pOfVoid : unit => Js_promise.t unit = "" [@@bs.module "promise"];
-external argPromise : p::Js_promise.t string => unit = "" [@@bs.module "promise"];
-external listOfPromises: unit => array (Js_promise.t string) = "" [@@bs.module "promise"];
-external somePromise : Js_promise.t (array float) = "" [@@bs.module "promise"];
+[@bs.module "promise"] external pOfString : unit => Js_promise.t(string) = "";
+
+[@bs.module "promise"] external pOfNumber : unit => Js_promise.t(float) = "";
+
+[@bs.module "promise"] external pOfArray : unit => Js_promise.t(array(string)) = "";
+
+[@bs.module "promise"] external pOfVoid : unit => Js_promise.t(unit) = "";
+
+[@bs.module "promise"] external argPromise : (~p: Js_promise.t(string)) => unit = "";
+
+[@bs.module "promise"] external listOfPromises : unit => array(Js_promise.t(string)) = "";
+
+[@bs.module "promise"] external somePromise : Js_promise.t(array(float)) = "";

--- a/lib/__tests__/fixtures/simple-class.js
+++ b/lib/__tests__/fixtures/simple-class.js
@@ -1,6 +1,6 @@
 declare module 'simple-class' {
   declare export class Test {
-    constructor(t: string): Test,
-    action(a: number): string
+    constructor(t: string): Test;
+    action<T, S>(a: number): string;
   }
 }

--- a/lib/__tests__/fixtures/simple-class.re
+++ b/lib/__tests__/fixtures/simple-class.re
@@ -1,4 +1,4 @@
 module Test = {
-  type t = Js.t {. action : (float => string) [@bs.meth]};
-  external make : string => t = "Test" [@@bs.new] [@@bs.module "simple-class"];
+  type t = {. "action": 't 's . [@bs.meth] (float => string)};
+  [@bs.new] [@bs.module "simple-class"] external make : string => t = "Test";
 };

--- a/lib/__tests__/fixtures/simple.re
+++ b/lib/__tests__/fixtures/simple.re
@@ -1,1 +1,1 @@
-external add : x::float => y::float => float = "" [@@bs.module "simple"];
+[@bs.module "simple"] external add : (~x: float, ~y: float) => float = "";

--- a/lib/__tests__/fixtures/spread-args.re
+++ b/lib/__tests__/fixtures/spread-args.re
@@ -1,7 +1,23 @@
-external foo : bars::array float => unit = "" [@@bs.module "spread-args"][@@bs.splice];
-external optFoo : bars::array float => unit = "" [@@bs.module "spread-args"][@@bs.splice];
-external bothFoo: anArg::string => bars::array float => unit = "" [@@bs.module "spread-args"][@@bs.splice];
-external bothOptFoo : anArg::string => bars::array float => unit = "" [@@bs.module "spread-args"][@@bs.splice];
-external soManyOpts: anArg::string? => unit => bars::array float => unit = "" [@@bs.module "spread-args"][@@bs.splice];
-external returns : anArg::string => bars::array float => float = "" [@@bs.module "spread-args"][@@bs.splice];
-external multipleLists : foos::array float => bars::array float => unit = "" [@@bs.module "spread-args"][@@bs.splice];
+[@bs.module "spread-args"] [@bs.splice] external foo : (~bars: array(float)) => unit = "";
+
+[@bs.module "spread-args"] [@bs.splice] external optFoo : (~bars: array(float)) => unit = "";
+
+[@bs.module "spread-args"] [@bs.splice]
+external bothFoo : (~anArg: string, ~bars: array(float)) => unit =
+  "";
+
+[@bs.module "spread-args"] [@bs.splice]
+external bothOptFoo : (~anArg: string, ~bars: array(float)) => unit =
+  "";
+
+[@bs.module "spread-args"] [@bs.splice]
+external soManyOpts : (~anArg: string=?, unit, ~bars: array(float)) => unit =
+  "";
+
+[@bs.module "spread-args"] [@bs.splice]
+external returns : (~anArg: string, ~bars: array(float)) => float =
+  "";
+
+[@bs.module "spread-args"] [@bs.splice]
+external multipleLists : (~foos: array(float), ~bars: array(float)) => unit =
+  "";

--- a/lib/__tests__/fixtures/type-decl.re
+++ b/lib/__tests__/fixtures/type-decl.re
@@ -1,3 +1,3 @@
-type stringOptions = Js.t {. value : string};
+type stringOptions = {. "value": string};
 
-external test : s::string => options::stringOptions => string = "" [@@bs.module "type-decl"];
+[@bs.module "type-decl"] external test : (~s: string, ~options: stringOptions) => string = "";

--- a/lib/__tests__/fixtures/union-type.re
+++ b/lib/__tests__/fixtures/union-type.re
@@ -1,2 +1,3 @@
-external double : x::[ | `Number float | `String string] [@bs.unwrap] => float =
-  "" [@@bs.module "union-type"];
+[@bs.module "union-type"]
+external double : (~x: [@bs.unwrap] [ | `Number(float) | `String(string)]) => float =
+  "";

--- a/lib/__tests__/fixtures/void-func.re
+++ b/lib/__tests__/fixtures/void-func.re
@@ -1,1 +1,1 @@
-external voidFunc : unit => unit = "" [@@bs.module "void-func"];
+[@bs.module "void-func"] external voidFunc : unit => unit = "";

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const refmt = require('refmt')
+const reason = require('reason')
 const { default: flowgen } = require('reasonable-flowgen')
 const Retyped = require('./retyped_node')
 
@@ -9,7 +9,22 @@ const Retyped = require('./retyped_node')
  * @return {string} Formatted Reason code
  */
 function format(source) {
-  const fmtedCode = refmt(source)
+  var fmtedCode = 'NotInitialized'
+  try {
+    fmtedCode = reason.printRE(reason.parseRE(source))
+  } catch (e) {
+    fmtedCode =
+      'line ' +
+      e.location.startLine +
+      ', characters ' +
+      e.location.startLineStartChar +
+      '-' +
+      e.location.endLineEndChar +
+      ', ' +
+      e.message +
+      '\n' +
+      source
+  }
 
   return fmtedCode
 }
@@ -38,7 +53,7 @@ function compile(source, filename = '', includeModule = false) {
 
   try {
     const [moduleName, bsCode] = Retyped.compile(filename, source)
-    const fmtCode = refmt(bsCode)
+    const fmtCode = format(bsCode)
     res = fmtCode
     resName = moduleName
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "flowgen": "^1.2.0",
     "meow": "^3.7.0",
     "reasonable-flowgen": "^0.1.3",
-    "refmt": "^1.13.7"
+    "reason": "^3.0.0"
   },
   "scripts": {
     "build:native": "jbuilder build src/cli.exe",

--- a/src/retyped/flowprinter.re
+++ b/src/retyped/flowprinter.re
@@ -9,7 +9,7 @@ let rec show_type =
   Modulegen.(
     fun
     | BsType.Regex => "RegExp"
-    | BsType.Optional(t) => show_type(t) ++ "?"
+    | BsType.Optional(t) => "?" ++ show_type(t)
     | BsType.Any => "any"
     | BsType.AnyObject => "Object"
     | BsType.AnyFunction => "Function"
@@ -65,11 +65,11 @@ let rec show_type =
         String.concat(
           ", ",
           List.map(
-            ((key, prop)) =>
+            ((key, prop, optional)) =>
               if (key == "$$callProperty") {
                 show_type(prop)
               } else {
-                format_obj_key(key) ++ (": " ++ show_type(prop))
+                format_obj_key(key) ++ (optional ? "?" : "") ++ ": " ++ show_type(prop)
               },
             props
           )

--- a/src/retyped/genutils.re
+++ b/src/retyped/genutils.re
@@ -10,15 +10,7 @@ let unquote = (str) => {
   }
 };
 
-let normalize_chars =
-  String.map(
-    (ch) =>
-      if (ch == '-' || ch == '$') {
-        '_'
-      } else {
-        ch
-      }
-  );
+let normalize_chars = String.map((ch) => ch == '-' || ch == '$' ? '_' : ch);
 
 let normalize_keywords =
   fun
@@ -156,7 +148,7 @@ let walk = (replacer) => {
     | Object(fields) as ot =>
       switch (replacer(ot)) {
       | Some(new_t) when recurse => walk_type(~recurse=false, new_t)
-      | _ => Object(List.map(((name, t)) => (name, walk_type(t)), fields))
+      | _ => Object(List.map(((name, t, optional)) => (name, walk_type(t), optional), fields))
       }
     | Class(extends, fields) as ct =>
       switch (replacer(ct)) {

--- a/src/retyped/render.re
+++ b/src/retyped/render.re
@@ -1,116 +1,84 @@
+let wrapParens = (l) => l == [] ? "" : "(" ++ String.concat(", ", l) ++ ")";
+
+let applyArgs = (name, l) => name ++ wrapParens(l);
+
+type lambdaArg =
+  | Labelled(string, bool)
+  | Unlabelled(string);
+
+let lambda = (l, body) => {
+  let arg = (a) =>
+    switch a {
+    | Labelled(label, optional) => "~" ++ label ++ (optional ? "=?" : "")
+    | Unlabelled(name) => name
+    };
+  wrapParens(List.map(arg, l)) ++ " => " ++ body
+};
+
+let quote = (x) => "\"" ++ x ++ "\"";
+
+let jsObject = (l) =>
+  "{" ++ (List.map(((k, v)) => quote(k) ++ ": " ++ v, l) |> String.concat(", ")) ++ "}";
+
 let variableDeclaration =
-    (
-      ~name,
-      ~module_id,
-      ~type_of,
-      ~is_exports=false,
-      ~splice=false,
-      ~code="",
-      ()
-    ) =>
+    (~name, ~module_id, ~type_of, ~is_exports=false, ~splice=false, ~code="", ()) =>
   if (is_exports) {
-    "external "
-    ++ (
-      name
-      ++ (
-        " : " ++ (type_of ++ (" = \"" ++ (module_id ++ "\" [@@bs.module];\n")))
-      )
-    )
+    "external " ++ name ++ " : " ++ type_of ++ " = \"" ++ module_id ++ "\" [@@bs.module];\n"
   } else {
-    "external "
-    ++ (
-      name
-      ++ (
-        " : "
-        ++ (
-          type_of
-          ++ (
-            " = \""
-            ++ (
-              code
-              ++ (
-                "\" [@@bs.module \""
-                ++ (
-                  module_id
-                  ++ ("\"]" ++ ((splice ? "[@@bs.splice]" : "") ++ ";\n"))
-                )
-              )
-            )
-          )
-        )
-      )
-    )
+    " [@bs.module \""
+    ++ module_id
+    ++ "\"]"
+    ++ (splice ? "[@bs.splice]" : "")
+    ++ "external "
+    ++ name
+    ++ " : "
+    ++ type_of
+    ++ " = \""
+    ++ code
+    ++ "\""
+    ++ ";\n"
   };
 
 let moduleDeclaration = (~name, ~statements, ()) =>
-  "module "
-  ++ (name ++ (" = {\n" ++ (String.concat("\n  ", statements) ++ "\n};")));
+  "module " ++ name ++ " = {\n" ++ String.concat("\n  ", statements) ++ "\n};";
 
-let classDeclaration =
-    (
-      ~name,
-      ~exported_as,
-      ~module_id,
-      ~class_type,
-      ~ctor_type,
-      ~type_params,
-      ()
-    ) =>
+let classDeclaration = (~name, ~exported_as, ~module_id, ~class_type, ~ctor_type, ~type_params, ()) =>
   "module "
-  ++ (
-    name
-    ++ (
-      " = {\n  type t "
-      ++ (
-        type_params
-        ++ (
-          " = "
-          ++ (
-            class_type
-            ++ (
-              ";\n  "
-              ++ (
-                "external make : "
-                ++ (
-                  ctor_type
-                  ++ (
-                    " = \""
-                    ++ (
-                      exported_as
-                      ++ (
-                        "\" [@@bs.new] [@@bs.module \""
-                        ++ (module_id ++ "\"];\n};")
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-  );
+  ++ name
+  ++ " = {\n  type "
+  ++ applyArgs("t", type_params)
+  ++ " = "
+  ++ class_type
+  ++ ";\n  "
+  ++ "[@bs.new] [@bs.module \""
+  ++ module_id
+  ++ "\"] "
+  ++ "external make : "
+  ++ ctor_type
+  ++ " = \""
+  ++ exported_as
+  ++ "\""
+  ++ ";\n};";
 
 let typeDeclaration = (~name, ~type_of, ~type_params, ()) =>
-  "type " ++ (name ++ (" " ++ (type_params ++ (" = " ++ (type_of ++ ";")))));
+  "type " ++ applyArgs(name, type_params) ++ " = " ++ type_of ++ ";";
 
 let objectType = (~statements, ()) =>
-  "Js.t {. "
+  "{. "
   ++ (
-    (
-      List.filter(((key, type_of)) => key != "__callProperty", statements)
-      |> List.map(((key, type_of)) => key ++ (": " ++ type_of))
-      |> String.concat(", ")
-    )
-    ++ " }"
-  );
+    List.filter(((key, type_of, _optional)) => key != "__callProperty", statements)
+    |> List.map(
+         ((key, type_of, optional)) =>
+           "\"" ++ key ++ "\"" ++ ": " ++ (optional ? "Js.Nullable.t(" ++ type_of ++ ")" : type_of)
+       )
+    |> String.concat(", ")
+  )
+  ++ " }";
 
-let functionType =
-    (~formal_params, ~rest_param, ~has_optional, ~return_type, ()) => {
+let functionType = (~formal_params, ~rest_param, ~has_optional, ~return_type, ()) => {
   let print = ((name, param_type)) =>
     if (name != "") {
-      name ++ ("::" ++ param_type)
+      "(~" ++ name ++ ":" ++ param_type ++ ")"
     } else {
       param_type
     };
@@ -130,7 +98,7 @@ let functionType =
     | Some(param) => print(param) ++ " => "
     | None => ""
     };
-  formalCode ++ (optUnit ++ (restCode ++ return_type))
+  formalCode ++ optUnit ++ restCode ++ return_type
 };
 
 let tupleType = (~types, ()) => "(" ++ (String.concat(", ", types) ++ ")");
@@ -138,164 +106,113 @@ let tupleType = (~types, ()) => "(" ++ (String.concat(", ", types) ++ ")");
 let unionTypeStrings = (~types, ()) =>
   "(["
   ++ (
-    (List.map((type_name) => "`" ++ type_name, types) |> String.concat(" | "))
-    ++ "] [@bs.string])"
+    (List.map((type_name) => "`" ++ type_name, types) |> String.concat(" | ")) ++ "] [@bs.string])"
   );
 
 let unionType = (~name, ~types, ()) =>
   "type union_of_"
+  ++ name
+  ++ " = "
   ++ (
-    name
-    ++ (
-      " = "
-      ++ (
-        (
-          List.map(
-            ((type_name, type_of)) =>
-              "\n| " ++ (type_name ++ (" (" ++ (type_of ++ ")"))),
-            types
-          )
-          |> String.concat("")
-        )
-        ++ (
-          ";\n\ntype "
-          ++ (
-            name
-            ++ (
-              ";\n\nexternal "
-              ++ (
-                name
-                ++ (
-                  " : union_of_"
-                  ++ (
-                    name
-                    ++ (
-                      " => "
-                      ++ (
-                        name
-                        ++ " = \"Array.prototype.shift.call\" [@@bs.val];\n"
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-      )
-    )
-  );
+    List.map(((type_name, type_of)) => "\n| " ++ (type_name ++ (" (" ++ (type_of ++ ")"))), types)
+    |> String.concat("")
+  )
+  ++ ";\n\ntype "
+  ++ name
+  ++ ";\n\nexternal "
+  ++ name
+  ++ " : union_of_"
+  ++ name
+  ++ " => "
+  ++ name
+  ++ " = \"Array.prototype.shift.call\" [@@bs.val];\n";
 
 let inlineUnion = (~types, ()) =>
-  "(["
+  "([@bs.unwrap] ["
   ++ (
-    (
-      List.map(
-        ((type_name, type_of)) => "`" ++ (type_name ++ (" " ++ type_of)),
-        types
-      )
-      |> String.concat(" | ")
-    )
-    ++ "] [@bs.unwrap])"
-  );
+    List.map(((type_name, type_of)) => "`" ++ type_name ++ "(" ++ type_of ++ ")", types)
+    |> String.concat(" | ")
+  )
+  ++ "])";
 
 let classType = (~types, ()) =>
-  "Js.t {. "
+  "{. "
   ++ (
-    (
-      List.filter(((key, _, type_of, _)) => key != "constructor", types)
-      |> List.map(
-           ((key, type_params, type_of, is_meth)) =>
-             key
-             ++ (
-               ": "
-               ++ (
-                 (
-                   switch type_params {
-                   | [] => ""
-                   | p => String.concat(" ", p) ++ " . "
-                   }
-                 )
-                 ++ (
-                   "(" ++ (type_of ++ (")" ++ (is_meth ? " [@bs.meth]" : "")))
-                 )
-               )
-             )
-         )
-      |> String.concat(", ")
-    )
-    ++ "}"
-  );
+    List.filter(((key, _, type_of, _)) => key != "constructor", types)
+    |> List.map(
+         ((key, type_params, type_of, is_meth)) =>
+           "\""
+           ++ key
+           ++ "\""
+           ++ ": "
+           ++ (
+             switch type_params {
+             | [] => ""
+             | p => String.concat(" ", p) ++ " . "
+             }
+           )
+           ++ (is_meth ? "[@bs.meth]" : "")
+           ++ "("
+           ++ type_of
+           ++ ")"
+       )
+    |> String.concat(", ")
+  )
+  ++ "}";
 
-let alias = (~name, ~value, ()) =>
-  "let " ++ (name ++ (" = " ++ (value ++ ";\n")));
+let alias = (~name, ~value) => "let " ++ name ++ " = " ++ value ++ ";\n";
 
 let react_component = (~module_name, ~component_name, ~js_name, ~props, ()) =>
   "\nmodule "
-  ++ (
-    component_name
-    ++ (
-      " = {\n  external "
-      ++ (
-        String.lowercase_ascii(component_name)
-        ++ (
-          "_reactComponent : ReasonReact.reactClass = \""
-          ++ (
-            js_name
-            ++ (
-              "\" [@@bs.module \""
-              ++ (
-                module_name
-                ++ (
-                  "\"];\n  let make "
-                  ++ (
-                    (
-                      List.map(
-                        ((name, _, t, optional, is_bool)) =>
-                          name ++ ("::(" ++ (name ++ (": " ++ (t ++ ")")))),
-                        props
-                      )
-                      |> String.concat(" ")
-                    )
-                    ++ (
-                      " children =>\n    ReasonReact.wrapJsForReason\n      reactClass::"
-                      ++ (
-                        String.lowercase_ascii(component_name)
-                        ++ (
-                          "_reactComponent\n      props::({"
-                          ++ (
-                            (
-                              List.map(
-                                ((name, js, t, optional, is_bool)) =>
-                                  "\""
-                                  ++ (
-                                    js
-                                    ++ (
-                                      "\": "
-                                      ++ (
-                                        (
-                                          is_bool ?
-                                            "Js.Boolean.to_js_boolean " : ""
-                                        )
-                                        ++ name
-                                      )
-                                    )
-                                  ),
-                                props
-                              )
-                              |> String.concat(", ")
-                            )
-                            ++ ("})\n      children;" ++ "\n};")
-                          )
-                        )
-                      )
-                    )
-                  )
-                )
+  ++ component_name
+  ++ " = {\n"
+  ++ "  [@bs.module \""
+  ++ module_name
+  ++ "\"]\n"
+  ++ "  external "
+  ++ String.lowercase_ascii(component_name)
+  ++ "_reactComponent : ReasonReact.reactClass = \""
+  ++ js_name
+  ++ "\""
+  ++ ";\n"
+  ++ "  let make = "
+  ++ lambda(
+       List.map(((name, _js, _t, optional, _is_bool)) => Labelled(name, optional), props)
+       @ [Unlabelled("children")],
+       "{"
+       ++ "\n    let props: props = "
+       ++ jsObject(
+            {
+              let wrapArg = (~optional, ~is_bool, x) =>
+                switch (optional, is_bool) {
+                | (true, false) => applyArgs("Js.Nullable.from_opt", [x])
+                | (true, true) =>
+                  let bind = (v, f) =>
+                    applyArgs(
+                      "Js.Nullable.bind",
+                      [v, "[@bs]" ++ lambda([Unlabelled("x")], applyArgs(f, ["x"]))]
+                    );
+                  bind(applyArgs("Js.Nullable.from_opt", [x]), "Js.Boolean.to_js_boolean")
+                | (false, true) => applyArgs("Js.Boolean.to_js_boolean", [x])
+                | (false, false) => x
+                };
+              List.map(
+                ((name, js, _t, optional, is_bool)) => (js, wrapArg(~optional, ~is_bool, name)),
+                props
               )
-            )
+            }
           )
-        )
-      )
-    )
-  );
+       ++ ";"
+       ++ "\n    "
+       ++ applyArgs(
+            "ReasonReact.wrapJsForReason",
+            [
+              "~reactClass=" ++ String.lowercase_ascii(component_name) ++ "_reactComponent",
+              "~props",
+              "children"
+            ]
+          )
+       ++ ";\n"
+       ++ "  }"
+     )
+  ++ "\n};";


### PR DESCRIPTION
Print code in Reason 3 syntax.
Support optional object properties.
Add test with React component, including optional properties that map to optional arguments passed to the make function.
Updated refmt using the reason npm package, which included refmt for Reason 3 syntax.

Updated snapshot tests.