### PR TITLE
Remove `flowgen`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "babel-code-frame": "^6.26.0",
     "chalk": "^2.1.0",
-    "flowgen": "^1.2.0",
     "meow": "^3.7.0",
     "reasonable-flowgen": "^0.1.3",
     "reason": "^3.0.0"


### PR DESCRIPTION
<!-- Please provide a brief description of the changes -->
<!-- If possible, provide sample input and output -->
As per [this comment](https://github.com/ReasonablyTyped/ReasonablyTyped/commit/14703429474f6d69ca2514ecbe81bcc89b1fbc5a#r25996463), `flowgen` is no longer required, since a custom fork is being used.
### PR Checklist
- [ ] Corresponding issue: #0000 
- [ ] Formatted code with `refmt`
- [ ] Ran tests `npm test` and updated snapshots
