### PR TITLE
Support implementation of component classes.

### DIFF
--- a/lib/__tests__/__snapshots__/compile.js.snap
+++ b/lib/__tests__/__snapshots__/compile.js.snap
@@ -1,17 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Compile ReactNamePicker.re 1`] = `
+"type myProps = {
+  .
+  \\"width\\": float,
+  \\"height\\": float
+};
+
+[@bs.module] external reactNamePicker : ReasonReact.reactClass = \\"ReactNamePicker.react\\";
+
+let make = (~width, ~height, children) => {
+  let props: myProps = {\\"width\\": width, \\"height\\": height};
+  ReasonReact.wrapJsForReason(~reactClass=reactNamePicker, ~props, children);
+};
+"
+`;
+
+exports[`Compile ReactNamePickerInlinedProps.re 1`] = `
+"[@bs.module]
+external reactNamePickerInlinedProps : ReasonReact.reactClass =
+  \\"ReactNamePickerInlinedProps.react\\";
+
+let make = (~width, ~height, children) => {
+  let props: {
+    .
+    \\"width\\": float,
+    \\"height\\": float
+  } = {\\"width\\": width, \\"height\\": height};
+  ReasonReact.wrapJsForReason(~reactClass=reactNamePickerInlinedProps, ~props, children);
+};
+"
+`;
+
 exports[`Compile component.re 1`] = `
-"type props = {. \\"input\\": Js.Nullable.t(string), \\"b\\": Js.Nullable.t(Js.boolean)};
+"type props = {
+  .
+  \\"input\\": Js.Nullable.t(string),
+  \\"b\\": Js.Nullable.t(Js.boolean)
+};
 
 module ReactComponent = {
-  [@bs.module \\"react-component\\"] external reactcomponent_reactComponent : ReasonReact.reactClass =
-    \\"ReactComponent\\";
+  [@bs.module \\"react-component\\"]
+  external reactComponent : ReasonReact.reactClass = \\"ReactComponent\\";
   let make = (~input=?, ~b=?, children) => {
     let props: props = {
       \\"input\\": Js.Nullable.from_opt(input),
       \\"b\\": Js.Nullable.bind(Js.Nullable.from_opt(b), [@bs] ((x) => Js.Boolean.to_js_boolean(x)))
     };
-    ReasonReact.wrapJsForReason(~reactClass=reactcomponent_reactComponent, ~props, children)
+    ReasonReact.wrapJsForReason(~reactClass=reactComponent, ~props, children);
   };
 };
 "
@@ -19,12 +55,10 @@ module ReactComponent = {
 
 exports[`Compile duplicate-type.re 1`] = `
 "[@bs.module \\"duplicate-type\\"]
-external add : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float =
-  \\"\\";
+external add : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float = \\"\\";
 
 [@bs.module \\"duplicate-type\\"]
-external sub : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float =
-  \\"\\";
+external sub : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float = \\"\\";
 "
 `;
 
@@ -48,7 +82,11 @@ module Adder = {
   [@bs.new] [@bs.module \\"generics\\"] external make : 'x => t('x) = \\"Adder\\";
 };
 
-type subOpts('m, 'n) = {. \\"m\\": 'm, \\"n\\": Adder.t('n)};
+type subOpts('m, 'n) = {
+  .
+  \\"m\\": 'm,
+  \\"n\\": Adder.t('n)
+};
 "
 `;
 
@@ -56,8 +94,7 @@ exports[`Compile interface.re 1`] = `
 "type options = {. \\"op\\": string};
 
 [@bs.module \\"interface\\"]
-external apply : (~x: float, ~y: float, ~options: options=?, unit) => float =
-  \\"\\";
+external apply : (~x: float, ~y: float, ~options: options=?, unit) => float = \\"\\";
 "
 `;
 
@@ -101,9 +138,17 @@ exports[`Compile numbers.re 2`] = `
 `;
 
 exports[`Compile object-type.re 1`] = `
-"type subscribeOptions = {. \\"start\\": float, \\"stop\\": float};
+"type subscribeOptions = {
+  .
+  \\"start\\": float,
+  \\"stop\\": float
+};
 
-type testOptions = {. \\"method\\": string, \\"subscribe\\": subscribeOptions};
+type testOptions = {
+  .
+  \\"method\\": string,
+  \\"subscribe\\": subscribeOptions
+};
 
 [@bs.module \\"object-type\\"] external test : (~options: testOptions) => string = \\"\\";
 "
@@ -150,24 +195,19 @@ exports[`Compile spread-args.re 1`] = `
 [@bs.module \\"spread-args\\"] [@bs.splice] external optFoo : (~bars: array(float)) => unit = \\"\\";
 
 [@bs.module \\"spread-args\\"] [@bs.splice]
-external bothFoo : (~anArg: string, ~bars: array(float)) => unit =
-  \\"\\";
+external bothFoo : (~anArg: string, ~bars: array(float)) => unit = \\"\\";
 
 [@bs.module \\"spread-args\\"] [@bs.splice]
-external bothOptFoo : (~anArg: string, ~bars: array(float)) => unit =
-  \\"\\";
+external bothOptFoo : (~anArg: string, ~bars: array(float)) => unit = \\"\\";
 
 [@bs.module \\"spread-args\\"] [@bs.splice]
-external soManyOpts : (~anArg: string=?, unit, ~bars: array(float)) => unit =
-  \\"\\";
+external soManyOpts : (~anArg: string=?, unit, ~bars: array(float)) => unit = \\"\\";
 
 [@bs.module \\"spread-args\\"] [@bs.splice]
-external returns : (~anArg: string, ~bars: array(float)) => float =
-  \\"\\";
+external returns : (~anArg: string, ~bars: array(float)) => float = \\"\\";
 
 [@bs.module \\"spread-args\\"] [@bs.splice]
-external multipleLists : (~foos: array(float), ~bars: array(float)) => unit =
-  \\"\\";
+external multipleLists : (~foos: array(float), ~bars: array(float)) => unit = \\"\\";
 "
 `;
 
@@ -180,8 +220,7 @@ exports[`Compile type-decl.re 1`] = `
 
 exports[`Compile union-type.re 1`] = `
 "[@bs.module \\"union-type\\"]
-external double : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float =
-  \\"\\";
+external double : (~x: [@bs.unwrap] [ | \`Number(float) | \`String(string)]) => float = \\"\\";
 "
 `;
 

--- a/lib/__tests__/fixtures/ReactNamePicker.js
+++ b/lib/__tests__/fixtures/ReactNamePicker.js
@@ -1,0 +1,20 @@
+/**
+ * @typechecks
+ * @flow
+ */
+
+const React = require('React')
+var { PropTypes } = React
+
+type myProps = { width: number, height: number }
+
+class ReactNamePicker extends React.Component<myProps> {
+  render() {
+    var wrapperTable = {
+      height: this.props.height,
+      width: this.props.width,
+      overflow: 'hidden'
+    }
+    return <div>"Hello"</div>
+  }
+}

--- a/lib/__tests__/fixtures/ReactNamePicker.re
+++ b/lib/__tests__/fixtures/ReactNamePicker.re
@@ -1,0 +1,8 @@
+type myProps = {. "width": float, "height": float};
+
+[@bs.module] external reactNamePicker : ReasonReact.reactClass = "ReactNamePicker.react";
+
+let make = (~width, ~height, children) => {
+  let props: myProps = {"width": width, "height": height};
+  ReasonReact.wrapJsForReason(~reactClass=reactNamePicker, ~props, children)
+};

--- a/lib/__tests__/fixtures/ReactNamePickerInlinedProps.js
+++ b/lib/__tests__/fixtures/ReactNamePickerInlinedProps.js
@@ -1,0 +1,21 @@
+/**
+ * @typechecks
+ * @flow
+ */
+
+const React = require('React')
+var { PropTypes } = React
+
+class ReactNamePickerInlinedProps extends React.Component<{
+  width: number,
+  height: number
+}> {
+  render() {
+    var wrapperTable = {
+      height: this.props.height,
+      width: this.props.width,
+      overflow: 'hidden'
+    }
+    return <div>"Hello"</div>
+  }
+}

--- a/lib/__tests__/fixtures/ReactNamePickerInlinedProps.re
+++ b/lib/__tests__/fixtures/ReactNamePickerInlinedProps.re
@@ -1,0 +1,7 @@
+[@bs.module] external reactNamePickerInlinedProps : ReasonReact.reactClass =
+  "ReactNamePickerInlinedProps.react";
+
+let make = (~width, ~height, children) => {
+  let props: {. "width": float, "height": float} = {"width": width, "height": height};
+  ReasonReact.wrapJsForReason(~reactClass=reactNamePickerInlinedProps, ~props, children)
+};

--- a/lib/__tests__/fixtures/component.re
+++ b/lib/__tests__/fixtures/component.re
@@ -1,13 +1,13 @@
 type props = {. "input": Js.Nullable.t(string), "b": Js.Nullable.t(Js.boolean)};
 
 module ReactComponent = {
-  [@bs.module "react-component"] external reactcomponent_reactComponent : ReasonReact.reactClass =
+  [@bs.module "react-component"] external reactComponent : ReasonReact.reactClass =
     "ReactComponent";
   let make = (~input=?, ~b=?, children) => {
     let props: props = {
       "input": Js.Nullable.from_opt(input),
       "b": Js.Nullable.bind(Js.Nullable.from_opt(b), [@bs] ((x) => Js.Boolean.to_js_boolean(x)))
     };
-    ReasonReact.wrapJsForReason(~reactClass=reactcomponent_reactComponent, ~props, children)
+    ReasonReact.wrapJsForReason(~reactClass=reactComponent, ~props, children)
   };
 };

--- a/src/retyped/compiler.re
+++ b/src/retyped/compiler.re
@@ -5,12 +5,18 @@ module Stage = {
     let (_, statements, _) = ocaml_ast;
     statements
   };
-  let make_typetable =
+  let make_module_typetable =
     fun
     | Modulegen.BsDecl.ModuleDecl(_, statements) => Typetable.create(statements)
     | _ => [];
-  let optimize_program = (program) => Optimizer.optimize(make_typetable(program), program);
-  let render_program = (program) => Codegen.program_to_code(program, make_typetable(program));
+  let optimize_program = (program) => Optimizer.optimize(make_module_typetable(program), program);
+  let optimize_programs = (programs) => List.map(optimize_program, programs);
+  let render_program = (globalTypeTable, program) =>
+    Codegen.program_to_code(program, make_module_typetable(program) @ globalTypeTable);
+  let render_programs = (programs) => {
+    let globalTypeTable = Typetable.create(programs);
+    List.map(render_program(globalTypeTable), programs)
+  };
   let combine_programs =
     List.fold_left(
       ((current_id, all_code), result) =>
@@ -32,9 +38,10 @@ module Stage = {
     };
     let show_types = (programs) => {
       print_endline("\027[1;36m=== Types ===\027[0m");
+      Typetable.show(Typetable.create(programs));
       List.iter(
         fun
-        | ModuleDecl(name, statements) as md => Typetable.show(make_typetable(md))
+        | ModuleDecl(name, statements) as md => Typetable.show(make_module_typetable(md))
         | _ => (),
         programs
       )
@@ -59,8 +66,8 @@ let compile = (~debug=false, module_name, module_def) => {
     Stage.parse_source(module_name, module_def)
     |> List.map(Modulegen.statement_to_program)
     |> Imports.link
-    |> List.map(Stage.optimize_program)
-    |> List.map(Stage.render_program)
+    |> Stage.optimize_programs
+    |> Stage.render_programs
     |> Stage.combine_programs;
   if (debug) {
     let debug_programs =

--- a/src/retyped/flowprinter.re
+++ b/src/retyped/flowprinter.re
@@ -108,6 +108,7 @@ let rec show_decl =
   Modulegen.(
     fun
     | BsDecl.Noop => ""
+    | BsDecl.Ignore(s) => "ignored: " ++ s
     | BsDecl.ExportsDecl(of_type) => "declare module.exports: " ++ show_type(of_type)
     | BsDecl.ModuleDecl(name, decls) =>
       "declare module "
@@ -151,4 +152,6 @@ let rec show_decl =
         )
         ++ (" } from '" ++ (module_name ++ "'\n"))
       )
+    | BsDecl.ReactClass(className, of_type) =>
+      "react class " ++ className ++ " with prop type " ++ show_type(of_type)
   );

--- a/src/retyped/modulegen.re
+++ b/src/retyped/modulegen.re
@@ -52,13 +52,7 @@ let loc_to_msg = ({source, start, _end}: Loc.t) =>
         ":"
         ++ (
           string_of_int(start.column)
-          ++ (
-            " to "
-            ++ (
-              string_of_int(_end.line)
-              ++ (":" ++ (string_of_int(_end.column) ++ "]"))
-            )
-          )
+          ++ (" to " ++ (string_of_int(_end.line) ++ (":" ++ (string_of_int(_end.column) ++ "]"))))
         )
       )
     )
@@ -108,18 +102,10 @@ let string_of_key = (key: Ast.Expression.Object.Property.key) =>
     switch value {
     | String(s) => s
     | _ =>
-      raise(
-        ModulegenTypeError(
-          sanity_check("Non-string as object property", {...intctx, loc})
-        )
-      )
+      raise(ModulegenTypeError(sanity_check("Non-string as object property", {...intctx, loc})))
     }
   | Computed((loc, _)) =>
-    raise(
-      ModulegenTypeError(
-        not_supported("Computed object properties", {...intctx, loc})
-      )
-    )
+    raise(ModulegenTypeError(not_supported("Computed object properties", {...intctx, loc})))
   };
 
 let extract_type_params = (ctx, type_parameters) => {
@@ -128,23 +114,11 @@ let extract_type_params = (ctx, type_parameters) => {
   let get_params = ((loc, {name, bound, variance, default})) =>
     switch (bound, variance, default) {
     | (Some(_), _, _) =>
-      raise(
-        ModulegenTypeError(
-          not_supported("Type parameter bounds", {...ctx, loc})
-        )
-      )
+      raise(ModulegenTypeError(not_supported("Type parameter bounds", {...ctx, loc})))
     | (_, Some(_), _) =>
-      raise(
-        ModulegenTypeError(
-          not_supported("Type parameter variance", {...ctx, loc})
-        )
-      )
+      raise(ModulegenTypeError(not_supported("Type parameter variance", {...ctx, loc})))
     | (_, _, Some(_)) =>
-      raise(
-        ModulegenTypeError(
-          not_supported("Type parameter defaults", {...ctx, loc})
-        )
-      )
+      raise(ModulegenTypeError(not_supported("Type parameter defaults", {...ctx, loc})))
     | _ => name
     };
   switch type_parameters {
@@ -182,10 +156,7 @@ and type_to_bstype = (ctx: context) =>
   | Boolean => BsType.Boolean
   | Function(f) => function_type_to_bstype(ctx, f)
   | Array((loc, t)) => BsType.Array(type_to_bstype({...ctx, loc}, t))
-  | Tuple(types) =>
-    BsType.Tuple(
-      List.map(((loc, t)) => type_to_bstype({...ctx, loc}, t), types)
-    )
+  | Tuple(types) => BsType.Tuple(List.map(((loc, t)) => type_to_bstype({...ctx, loc}, t), types))
   | Intersection((loc_a, first), (loc_b, second), rest) =>
     raise(ModulegenTypeError(not_supported("Intersection types", ctx)))
   | Union((loc_a, first), (loc_b, second), rest) =>
@@ -206,10 +177,7 @@ and function_type_to_bstype = (ctx, f) => {
   open Ast.Type.Function.Param;
   let {params: (formal, rest), returnType: (rt_loc, rt), typeParameters} = f;
   let type_params = extract_type_params(ctx, typeParameters);
-  let arg_types =
-      (
-        (_, {typeAnnotation: (loc, t), name, optional}): Ast.Type.Function.Param.t
-      ) => (
+  let arg_types = ((_, {typeAnnotation: (loc, t), name, optional}): Ast.Type.Function.Param.t) => (
     switch name {
     | Some(id) => string_of_id(id)
     | None => ""
@@ -265,27 +233,16 @@ and object_type_to_bstype = ({properties}) =>
         if (static) {
           raise(
             ModulegenTypeError(
-              not_supported(
-                "static CallProperty on Object types",
-                {...intctx, loc}
-              )
+              not_supported("static CallProperty on Object types", {...intctx, loc})
             )
           )
         };
         ("$$callProperty", type_to_bstype({...intctx, loc}, Function(value)), false)
       }
     | Indexer((loc, _)) =>
-      raise(
-        ModulegenTypeError(
-          not_supported("Indexer on Object types", {...intctx, loc})
-        )
-      )
+      raise(ModulegenTypeError(not_supported("Indexer on Object types", {...intctx, loc})))
     | SpreadProperty((loc, _)) =>
-      raise(
-        ModulegenTypeError(
-          not_supported("SpreadProperty on Object types", {...intctx, loc})
-        )
-      ),
+      raise(ModulegenTypeError(not_supported("SpreadProperty on Object types", {...intctx, loc}))),
     properties
   )
 and generic_type_to_bstype = (ctx, g) => {
@@ -307,18 +264,10 @@ and named_to_bstype = (ctx, type_params, (loc, id)) =>
     let params =
       switch type_params {
       | Some((_, {params: []})) =>
-        raise(
-          ModulegenTypeError(
-            not_supported("Array with no types", {...ctx, loc})
-          )
-        )
+        raise(ModulegenTypeError(not_supported("Array with no types", {...ctx, loc})))
       | Some((_, {params})) => params
       | None =>
-        raise(
-          ModulegenTypeError(
-            not_supported("Array with more than one type", {...ctx, loc})
-          )
-        )
+        raise(ModulegenTypeError(not_supported("Array with more than one type", {...ctx, loc})))
       };
     let (loc, inner_type) = List.hd(params);
     BsType.Array(type_to_bstype({...ctx, loc}, inner_type))
@@ -329,11 +278,7 @@ and named_to_bstype = (ctx, type_params, (loc, id)) =>
       switch type_params {
       | Some((_, {params: [type_param]})) => type_param
       | None =>
-        raise(
-          ModulegenTypeError(
-            "Class must have exactly one type parameter. Found none."
-          )
-        )
+        raise(ModulegenTypeError("Class must have exactly one type parameter. Found none."))
       | Some((_, {params})) =>
         raise(
           ModulegenTypeError(
@@ -349,11 +294,7 @@ and named_to_bstype = (ctx, type_params, (loc, id)) =>
       switch type_params {
       | Some((_, {params: [type_param]})) => type_param
       | None =>
-        raise(
-          ModulegenTypeError(
-            "Promise must have exactly one type parameter. Found none."
-          )
-        )
+        raise(ModulegenTypeError("Promise must have exactly one type parameter. Found none."))
       | Some((_, {params})) =>
         raise(
           ModulegenTypeError(
@@ -364,19 +305,14 @@ and named_to_bstype = (ctx, type_params, (loc, id)) =>
       };
     BsType.Promise(type_to_bstype({...ctx, loc}, inner_type))
   | _ =>
-    if (String.length(id) > 0
-        && id.[0] == '$'
-        && String.sub(id, 0, 4) != "$npm") {
+    if (String.length(id) > 0 && id.[0] == '$' && String.sub(id, 0, 4) != "$npm") {
       raise(ModulegenTypeError(not_supported("Built-in type " ++ id, ctx)))
     } else {
       let type_params =
         switch type_params {
         | None => []
         | Some((_, {params})) =>
-          List.map(
-            ((loc, type_of)) => type_to_bstype({...ctx, loc}, type_of),
-            params
-          )
+          List.map(((loc, type_of)) => type_to_bstype({...ctx, loc}, type_of), params)
         };
       BsType.Named(type_params, id, None)
     }
@@ -400,18 +336,19 @@ module BsDecl = {
     | InterfaceDecl(string, list(string), BsType.t)
     /* import {names as name} from {module} */
     | ImportDecl(list((string, string)), string)
+    /* react class: name of the class, props type */
+    | ReactClass(string, BsType.t)
     /* Nothing */
-    | Noop;
+    | Noop
+    /* declaration currently ignored */
+    | Ignore(string);
 };
 
 let rec declaration_to_jsdecl = (loc) =>
   Ast.Statement.Interface.(
     fun
     | Variable((loc, {id, typeAnnotation})) =>
-      BsDecl.VarDecl(
-        string_of_id(id),
-        type_annotation_to_bstype(typeAnnotation)
-      )
+      BsDecl.VarDecl(string_of_id(id), type_annotation_to_bstype(typeAnnotation))
     | Function((loc, {id, typeAnnotation})) => {
         let bstype = type_annotation_to_bstype(Some(typeAnnotation));
         BsDecl.FuncDecl(string_of_id(id), bstype)
@@ -420,8 +357,7 @@ let rec declaration_to_jsdecl = (loc) =>
     | _ =>
       raise(
         ModulegenDeclError(
-          "Unknown declaration when converting a module property declaration"
-          ++ loc_to_msg(loc)
+          "Unknown declaration when converting a module property declaration" ++ loc_to_msg(loc)
         )
       )
   )
@@ -431,11 +367,7 @@ and declare_interface_to_jsdecl = (loc, s) => {
   let {id, body, typeParameters, extends} = s;
   switch extends {
   | [(loc, _extends), ...t] =>
-    raise(
-      ModulegenStatementError(
-        not_supported("Inheriting in interfaces", {...intctx, loc})
-      )
-    )
+    raise(ModulegenStatementError(not_supported("Inheriting in interfaces", {...intctx, loc})))
   | _ => ()
   };
   let (body_loc, obj_type) = body;
@@ -453,17 +385,14 @@ and declare_class_to_jsdecl = (loc, s) => {
   let inheritedClasses =
     switch extends {
     | [] => None
-    | [(loc, parent)] =>
-      Some(type_to_bstype({...intctx, loc}, Ast.Type.Generic(parent)))
+    | [(loc, parent)] => Some(type_to_bstype({...intctx, loc}, Ast.Type.Generic(parent)))
     | _ =>
       raise(
-        ModulegenStatementError(
-          not_supported("Inheriting from multiple types", {...intctx, loc})
-        )
+        ModulegenStatementError(not_supported("Inheriting from multiple types", {...intctx, loc}))
       )
     };
   let properties = object_type_to_bstype(interface);
-  let properties = List.map (((x,y,z)) => (x,y), properties);
+  let properties = List.map(((x, y, z)) => (x, y), properties);
   BsDecl.ClassDecl(
     string_of_id(id),
     extract_type_params(intctx, typeParameters),
@@ -496,17 +425,9 @@ let import_decl_to_jsdecl = (loc, s) => {
       );
     BsDecl.ImportDecl(import_names, imported_module)
   | ImportTypeof =>
-    raise(
-      ModulegenStatementError(
-        not_supported("'import typeof'", {...intctx, loc})
-      )
-    )
+    raise(ModulegenStatementError(not_supported("'import typeof'", {...intctx, loc})))
   | ImportValue =>
-    raise(
-      ModulegenStatementError(
-        not_supported("Importing values", {...intctx, loc})
-      )
-    )
+    raise(ModulegenStatementError(not_supported("Importing values", {...intctx, loc})))
   }
 };
 
@@ -531,13 +452,9 @@ let rec statement_to_program = ((loc, s)) =>
       if (string_of_id(id) == "exports") {
         BsDecl.ExportsDecl(type_annotation_to_bstype(typeAnnotation))
       } else {
-        BsDecl.VarDecl(
-          string_of_id(id),
-          type_annotation_to_bstype(typeAnnotation)
-        )
+        BsDecl.VarDecl(string_of_id(id), type_annotation_to_bstype(typeAnnotation))
       }
-    | Ast.Statement.InterfaceDeclaration(s) =>
-      declare_interface_to_jsdecl(loc, s)
+    | Ast.Statement.InterfaceDeclaration(s) => declare_interface_to_jsdecl(loc, s)
     | Ast.Statement.DeclareInterface(s) => declare_interface_to_jsdecl(loc, s)
     | Ast.Statement.DeclareTypeAlias({id, typeParameters, right: (loc, t)}) =>
       BsDecl.TypeDecl(
@@ -547,35 +464,30 @@ let rec statement_to_program = ((loc, s)) =>
       )
     | Ast.Statement.ImportDeclaration(s) => import_decl_to_jsdecl(loc, s)
     | Ast.Statement.DeclareOpaqueType(_) =>
-      raise(
-        ModulegenStatementError(
-          not_supported("Opaque types", {...intctx, loc})
-        )
-      )
+      raise(ModulegenStatementError(not_supported("Opaque types", {...intctx, loc})))
+    | Ast.Statement.ClassDeclaration({
+        id: Some((_loc, className)),
+        superClass:
+          Some((_, Member({_object: (_, Identifier(oID)), property: PropertyIdentifier(pID)}))),
+        superTypeParameters: Some((_, {params: [(_, propt), ..._]}))
+      })
+        when
+          string_of_id(oID) == "React"
+          && (string_of_id(pID) == "Component" || string_of_id(pID) == "PureComponent") =>
+      let propsType = type_to_bstype({...intctx, loc}, propt);
+      BsDecl.ReactClass(className, propsType)
     | Ast.Statement.ClassDeclaration(_) =>
-      raise(
-        ModulegenStatementError(
-          not_supported("Class declatations", {...intctx, loc})
-        )
-      )
+      raise(ModulegenStatementError(not_supported("Class declatations", {...intctx, loc})))
     | Ast.Statement.Empty => BsDecl.Noop
     | Ast.Statement.ExportDefaultDeclaration(_) =>
-      raise(
-        ModulegenStatementError(
-          not_supported("ExportDefaultDeclaration", {...intctx, loc})
-        )
-      )
+      raise(ModulegenStatementError(not_supported("ExportDefaultDeclaration", {...intctx, loc})))
     | Ast.Statement.ExportNamedDeclaration(_) =>
-      raise(
-        ModulegenStatementError(
-          not_supported("ExportNamedDeclaration", {...intctx, loc})
-        )
-      )
+      raise(ModulegenStatementError(not_supported("ExportNamedDeclaration", {...intctx, loc})))
+    | Ast.Statement.VariableDeclaration(_) => BsDecl.Ignore("variable declaration")
+    | Ast.Statement.Expression(_) => BsDecl.Ignore("expression statement")
     | _ =>
       raise(
-        ModulegenStatementError(
-          "Unknown statement type when parsing libdef" ++ loc_to_msg(loc)
-        )
+        ModulegenStatementError("Unknown statement type when parsing libdef" ++ loc_to_msg(loc))
       )
     }
   )
@@ -588,8 +500,7 @@ and declare_module_to_jsdecl = (loc, s) => {
   | _ =>
     raise(
       ModulegenDeclError(
-        "Unknown declaration type when converting a module declaration"
-        ++ loc_to_msg(loc)
+        "Unknown declaration type when converting a module declaration" ++ loc_to_msg(loc)
       )
     )
   }

--- a/src/retyped/typetable.re
+++ b/src/retyped/typetable.re
@@ -35,20 +35,16 @@ let show = (table) => {
     ((id, typeof)) =>
       print_endline(
         "typeof "
+        ++ id
+        ++ " = "
         ++ (
-          id
-          ++ (
-            " = "
-            ++ (
-              switch typeof {
-              | Class => "Class"
-              | None => "None"
-              | NotFound => "NotFound"
-              | Variable(s) => "typeof " ++ s
-              | Type(t) => Flowprinter.show_type(t)
-              }
-            )
-          )
+          switch typeof {
+          | Class => "Class"
+          | None => "None"
+          | NotFound => "NotFound"
+          | Variable(s) => "typeof " ++ s
+          | Type(t) => Flowprinter.show_type(t)
+          }
         )
       ),
     table


### PR DESCRIPTION
Support class implementations extending React.Component.

The type of props is extracted similarly to pure export declarations.

Support ignoring some statements present in implementations, but not essential to extract the type of components.

Support inlining of prop types.

Extend treatment of type tables with a global table of all the toplevel type definitions.

Add tests for components defined with and without inlining the type of props.
